### PR TITLE
Read table row filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,12 @@ LazyData: true
 Imports: 
     odbc (>= 1.3.3),
     DBI,
+    dbplyr,
+    rlang,
     glue
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 2.1.0),
     mockery

--- a/R/create_replace_table.R
+++ b/R/create_replace_table.R
@@ -435,7 +435,7 @@ clean_column_names <- function(input_df, table_name) {
     replacement = "_"
   ))
   # Make unique by numbering duplicates
-  column_names <- make.unique(column_names, sep="")
+  column_names <- make.unique(column_names, sep = "")
   # Assign and return df
   colnames(input_df) <- column_names
   input_df

--- a/R/drop_table.R
+++ b/R/drop_table.R
@@ -34,7 +34,6 @@ create_drop_sql <- function(server,
                             table_name,
                             versioned_table) {
   if (versioned_table) {
-
     # Check is versioned table regardless of versioned_table input arg
     check_sql <- create_check_sql(schema, table_name)
     check_df <- execute_sql(
@@ -45,7 +44,7 @@ create_drop_sql <- function(server,
     )
     if (is_versioned(check_df)) {
       drop_sql <- create_drop_sql_versioned(schema, table_name)
-    } else { #if not actually versioned:
+    } else { # if not actually versioned:
       drop_sql <- create_drop_sql_nonversioned(schema, table_name)
     }
   } else { # If versioned_table argument is FALSE

--- a/R/drop_table.R
+++ b/R/drop_table.R
@@ -45,14 +45,10 @@ create_drop_sql <- function(server,
     )
     if (is_versioned(check_df)) {
       drop_sql <- create_drop_sql_versioned(schema, table_name)
-    }
-    # In case use the versioned_table argument as TRUE but not versioned table
-    else {
+    } else { #if not actually versioned:
       drop_sql <- create_drop_sql_nonversioned(schema, table_name)
     }
-  }
-  # If versioned_table argument is FALSE
-  else {
+  } else { # If versioned_table argument is FALSE
     drop_sql <- create_drop_sql_nonversioned(schema, table_name)
   }
   return(drop_sql)

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -15,6 +15,7 @@ format_filter <- function(server, database, filter_stmt) {
     con = connection
   )
   DBI::dbDisconnect(connection)
+  sql <- as.character(sql)
   gsub("(`|\")([^=]*)\\1", "[\\2]", sql)
 }
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -2,7 +2,7 @@ table_select_list <- function(columns) {
   if (is.null(columns)) {
     "*"
   } else {
-    glue::glue_collapse(glue::glue("{columns}"), sep = ", ")
+    glue::glue_collapse(glue::glue("[{columns}]"), sep = ", ")
   }
 }
 
@@ -11,9 +11,10 @@ format_filter <- function(server, database, filter_stmt) {
     server = server,
     database = database
   )
-  sql <- dbplyr::translate_sql(!! rlang::parse_expr(filter_stmt), con=connection)
+  sql <- dbplyr::translate_sql(!! rlang::parse_expr(filter_stmt),
+                               con=connection)
   DBI::dbDisconnect(connection)
-  sql
+  gsub("\"(.*?)\"", "\\[\\1]", sql)
 }
 
 create_read_sql <- function(server,

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -15,7 +15,7 @@ format_filter <- function(server, database, filter_stmt) {
     con = connection
   )
   DBI::dbDisconnect(connection)
-  gsub("\"(.*?)\"", "\\[\\1]", sql)
+  gsub("(`|\")([^=]*)\\1", "[\\2]", sql)
 }
 
 create_read_sql <- function(server,

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -6,22 +6,55 @@ table_select_list <- function(columns) {
   }
 }
 
-create_read_sql <- function(select_list, schema, table_name) {
-  glue::glue(
+format_filter <- function(server, database, filter_stmt) {
+  connection <- create_sqlserver_connection(
+    server = server,
+    database = database
+  )
+  sql <- dbplyr::translate_sql(!! rlang::parse_expr(filter_stmt), con=connection)
+  DBI::dbDisconnect(connection)
+  sql
+}
+
+create_read_sql <- function(server,
+                            database,
+                            schema,
+                            select_list,
+                            table_name,
+                            filter_stmt) {
+  initial_sql <- glue::glue(
     "SELECT {select_list}",
-    "FROM [{schema}].[{table_name}];",
+    "FROM [{schema}].[{table_name}]",
     .sep = " "
   )
+  if (!is.null(filter_stmt)) {
+    filter_stmt <- format_filter(server, database, filter_stmt)
+    glue::glue(
+      initial_sql,
+      "WHERE {filter_stmt};",
+      .sep = " "
+    )
+  } else {
+    glue::glue(initial_sql, ";")
+  }
 }
 
 
-#' Read a SQL Server table into an R dataframe,
+#' Read a SQL Server table into an R dataframe.
+#'
+#' If you are confident in writing SQL you may prefer to
+#' Use \link[RtoSQLServer]{execute_sql} function instead.
+#'
 #'
 #' @param server Server instance where SQL Server database running.
 #' @param database Database containing table to read.
 #' @param schema Name of database schema containing table to read.
 #' @param table_name Name of table in database to read.
 #' @param columns Optional vector of column names to select.
+#' @param filter_stmt Optional filter statement - this should be a character
+#' expression in the format of a `dplyr::filter()` query,
+#' for example `"Species == "virginica"` and it will be translated to SQL
+#' using \link[dbplyr]{translate_sql}.
 #'
 #' @return Dataframe of table.
 #' @export
@@ -32,14 +65,16 @@ create_read_sql <- function(select_list, schema, table_name) {
 #'   database = "my_database",
 #'   server = "my_server",
 #'   table_name = "my_table",
-#'   columns = c("column1", "column2")
+#'   columns = c("column1", "column2"),
+#'   filter_stmt = "column1 < 5 & column2 == 'b'")
 #' )
 #' }
 read_table_from_db <- function(database,
                                server,
                                schema,
                                table_name,
-                               columns = NULL) {
+                               columns = NULL,
+                               filter_stmt = NULL) {
   if (!check_table_exists(
     server,
     database,
@@ -53,11 +88,14 @@ read_table_from_db <- function(database,
   select_list <- table_select_list(columns)
 
   read_sql <- create_read_sql(
-    select_list,
+    server,
+    database,
     schema,
-    table_name
+    select_list,
+    table_name,
+    filter_stmt
   )
-
+  message(glue::glue("Read SQL statement:\n{read_sql}"))
   execute_sql(
     database = database, server =
       server, sql = read_sql, output = TRUE

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -68,7 +68,7 @@ create_read_sql <- function(server,
 #'   server = "my_server",
 #'   table_name = "my_table",
 #'   columns = c("column1", "column2"),
-#'   filter_stmt = "column1 < 5 & column2 == 'b'")
+#'   filter_stmt = "column1 < 5 & column2 == 'b'"
 #' )
 #' }
 read_table_from_db <- function(database,

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -2,7 +2,7 @@ table_select_list <- function(columns) {
   if (is.null(columns)) {
     "*"
   } else {
-    glue::glue_collapse(glue::glue("[{columns}]"), sep = ", ")
+    glue::glue_collapse(glue::glue("{columns}"), sep = ", ")
   }
 }
 
@@ -43,7 +43,7 @@ create_read_sql <- function(server,
 #' Read a SQL Server table into an R dataframe.
 #'
 #' If you are confident in writing SQL you may prefer to
-#' Use \link[RtoSQLServer]{execute_sql} function instead.
+#' use the [RtoSQLServer::execute_sql()] function instead.
 #'
 #'
 #' @param server Server instance where SQL Server database running.
@@ -52,9 +52,9 @@ create_read_sql <- function(server,
 #' @param table_name Name of table in database to read.
 #' @param columns Optional vector of column names to select.
 #' @param filter_stmt Optional filter statement - this should be a character
-#' expression in the format of a `dplyr::filter()` query,
-#' for example `"Species == "virginica"` and it will be translated to SQL
-#' using \link[dbplyr]{translate_sql}.
+#' expression in the format of a [dplyr::filter()] query,
+#' for example `"Species == 'virginica'"` and it will be translated to SQL
+#' using [dbplyr::translate_sql()].
 #'
 #' @return Dataframe of table.
 #' @export

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -11,8 +11,9 @@ format_filter <- function(server, database, filter_stmt) {
     server = server,
     database = database
   )
-  sql <- dbplyr::translate_sql(!! rlang::parse_expr(filter_stmt),
-                               con=connection)
+  sql <- dbplyr::translate_sql(!!rlang::parse_expr(filter_stmt),
+    con = connection
+  )
   DBI::dbDisconnect(connection)
   gsub("\"(.*?)\"", "\\[\\1]", sql)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,7 +190,7 @@ compatible_cols <- function(existing_col_type,
     return("missing sql")
   } else if (is.na(to_load_col_type)) {
     return("missing df")
-  }else if (existing_col_type == to_load_col_type) {
+  } else if (existing_col_type == to_load_col_type) {
     return("compatible")
   } else if (!(grepl("nvarchar", existing_col_type) &&
     grepl("nvarchar", to_load_col_type)

--- a/R/utils.R
+++ b/R/utils.R
@@ -142,9 +142,9 @@ r_to_sql_character_sizes <- function(max_string) {
   max_string <- as.numeric(max_string)
   if (max_string <= 50) {
     "nvarchar(50)"
-  } else if (max_string > 50 & max_string <= 255) {
+  } else if (max_string > 50 && max_string <= 255) {
     "nvarchar(255)"
-  } else if (max_string > 255 & max_string <= 4000) {
+  } else if (max_string > 255 && max_string <= 4000) {
     "nvarchar(4000)"
   } else {
     "nvarchar(max)"
@@ -164,7 +164,7 @@ r_to_sql_data_type <- function(col_v) {
   r_data_type <- class(col_v)
   if (r_data_type %in% c("character", "factor")) {
     col_v <- as.character(col_v) # to ensure factor cols are character
-    max_string <- max(nchar(col_v), na.rm=TRUE)
+    max_string <- max(nchar(col_v), na.rm = TRUE)
   }
   switch(r_data_type,
     "numeric" = "float",
@@ -185,29 +185,18 @@ get_nvarchar_size <- function(input_char_type) {
 
 compatible_cols <- function(existing_col_type,
                             to_load_col_type) {
-
   # If existing is na then column not in sql db
   if (is.na(existing_col_type)) {
     return("missing sql")
-  }
-
-  # If to load is na then not in to load df
-  else if (is.na(to_load_col_type)) {
+  } else if (is.na(to_load_col_type)) {
     return("missing df")
-  }
-
-  # Identical columns of any type are fine
-  else if (existing_col_type == to_load_col_type) {
+  }else if (existing_col_type == to_load_col_type) {
     return("compatible")
-  }
-  # Else only if both column data_types contain "nvarchar" then proceed
-
-  else if (!(grepl("nvarchar", existing_col_type) &
+  } else if (!(grepl("nvarchar", existing_col_type) &&
     grepl("nvarchar", to_load_col_type)
   )) {
     return("incompatible")
-  }
-  else {
+  } else {
     # Extract the nvarchar column size, e.g. 255 from nvarchar(255)
     existing_col_size <- get_nvarchar_size(existing_col_type)
     to_load_col_size <- get_nvarchar_size(to_load_col_type)
@@ -219,8 +208,7 @@ compatible_cols <- function(existing_col_type,
     <= as.numeric(existing_col_size)) {
       return("compatible") # If neither is max, but existing greater
       # than or equal to load then will be fine
-    }
-    else {
+    } else {
       return("resize") # If neither is max, but existing smaller
       # than to load then must resize
     }

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,9 +44,9 @@ remotes::install_local("C:/temp/RtoSQLServer-main.zip", upgrade="never")
 
 As well as loading R dataframes into SQL Server databases, functions are also currently available to: 
 
-- Select all rows of specific columns of a database table.
+- Read a database table into an R dataframe, optionally specifying a subset of table columns or row filter.
 - Drop a table from the database.
-- Run any other input sql in the database and return dataframe if a select statement.  
+- Run any other input sql in the database and return a dataframe if a select statement.  
 
 It is recommend to ensure using the latest versions of [Rcpp](https://cran.r-project.org/web/packages/Rcpp/index.html), [odbc](https://cran.r-project.org/web/packages/odbc/index.html) and [DBI](https://cran.r-project.org/web/packages/DBI/index.html). If using Windows in a secure environment install these from source or a Windows binary compiled at the version of R you are using.
 
@@ -137,8 +137,28 @@ drop_table_from_db(
   table_name = "test_r_tbl"
 )
 ```
+## Read database table with column or row filtering
+The `read_table_from_db` function includes optional arguments so you can read only specific columns into an R dataframe or so you can filter which rows are read.  
 
-## Why use this package
+To select only specific columns, specify a vector of column_names for example `c("Sepal_Length", "Species")` for the `columns` argument of `read_table_from_db`.  
+
+To select only specific rows, specify a filter string using R syntax (not SQL syntax) for the `filter_stmt` argument. For example `"(Species == 'setosa' | Species == 'virginica') & Sepal_Length > 5.0"`. The function will convert this to SQL.
+
+Here's a full example of both column and row selection using the `columns` and `filter_stmt` arguments of `read_table_from_db` for a copy of the iris data loaded into the database:
+
+```{r eval=FALSE}
+db_test_iris <- read_table_from_db(
+  server = server,
+  database = database,
+  schema = schema,
+  table_name = "test_iris",
+  columns = c("Sepal_Length", "Species"),
+  filter_stmt = "(Species == 'setosa' | Species == 'virginica') & Sepal_Length > 5.0"
+)
+```
+If you are comfortable with SQL, you may prefer to use the `execute_sql` function where a SQL select statement can be input to return an R dataframe from a database.
+
+## Background Information - Why use this package
 The `RtoSQLServer` package relies on `DBI` and `odbc` packages for its database functionality, however you should consider using it instead of `DBI` or `odbc` for the following reasons:
 
 #### Importing large dataframes

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ remotes::install_local("C:/temp/RtoSQLServer-main.zip", upgrade="never")
 As well as loading R dataframes into SQL Server databases, functions are
 also currently available to:
 
-- Select all rows of specific columns of a database table.
+- Read a database table into an R dataframe, optionally specifying a
+  subset of table columns or row filter.
 - Drop a table from the database.
-- Run any other input sql in the database and return dataframe if a
+- Run any other input sql in the database and return a dataframe if a
   select statement.
 
 It is recommend to ensure using the latest versions of
@@ -151,7 +152,41 @@ drop_table_from_db(
 )
 ```
 
-## Why use this package
+## Read database table with column or row filtering
+
+The `read_table_from_db` function includes optional arguments so you can
+read only specific columns into an R dataframe or so you can filter
+which rows are read.
+
+To select only specific columns, specify a vector of column_names for
+example `c("Sepal_Length", "Species")` for the `columns` argument of
+`read_table_from_db`.
+
+To select only specific rows, specify a filter string using R syntax
+(not SQL syntax) for the `filter_stmt` argument. For example
+`"(Species == 'setosa' | Species == 'virginica') & Sepal_Length > 5.0"`.
+The function will convert this to SQL.
+
+Here’s a full example of both column and row selection using the
+`columns` and `filter_stmt` arguments of `read_table_from_db` for a copy
+of the iris data loaded into the database:
+
+``` r
+db_test_iris <- read_table_from_db(
+  server = server,
+  database = database,
+  schema = schema,
+  table_name = "test_iris",
+  columns = c("Sepal_Length", "Species"),
+  filter_stmt = "(Species == 'setosa' | Species == 'virginica') & Sepal_Length > 5.0"
+)
+```
+
+If you are comfortable with SQL, you may prefer to use the `execute_sql`
+function where a SQL select statement can be input to return an R
+dataframe from a database.
+
+## Background Information - Why use this package
 
 The `RtoSQLServer` package relies on `DBI` and `odbc` packages for its
 database functionality, however you should consider using it instead of

--- a/demo/example_usage.R
+++ b/demo/example_usage.R
@@ -36,7 +36,7 @@ write_dataframe_to_db(
 # In this example we are just appending the same dataframe to the existing
 # table.
 # Must ensure the existing table and the dataframe to be appended hold the same
-#columns
+# columns
 # If specified append_to_existing=FALSE then the existing table is overwritten
 
 write_dataframe_to_db(

--- a/demo/example_usage.R
+++ b/demo/example_usage.R
@@ -13,9 +13,10 @@ database <- "admdemothemeadmdemotopic"
 schema <- "admdemodataitem"
 
 
-# Write a new dataframe to the database -----------------------------------------
+# Write a new dataframe to the database --------------------------------------
 
-#  NOTE: When loading, make sure the table_name specified above only contains chracters, numbers and _ (this will be automatically corrected if not)
+#  NOTE: When loading, make sure the table_name specified above only contains
+# chracters, numbers and _ (this will be automatically corrected if not)
 
 
 write_dataframe_to_db(
@@ -25,15 +26,17 @@ write_dataframe_to_db(
   table_name = "test_iris",
   dataframe = test_iris,
   append_to_existing = FALSE, # Set as FALSE to overwrite table if exists
-  batch_size = 1e5, # Set as any integer or leave as default if less than about 100 K rows
+  batch_size = 1e5, # Set as any integer or leave as default
   versioned_table = FALSE
 ) # Unless definitely need history table, set as FALSE (default)
 
 
 # Append to existing table in the database --------------------------------
 
-# In this example we are just appending the same dataframe to the existing table.
-# Must ensure the existing table and the dataframe to be appended hold the same columns
+# In this example we are just appending the same dataframe to the existing
+# table.
+# Must ensure the existing table and the dataframe to be appended hold the same
+#columns
 # If specified append_to_existing=FALSE then the existing table is overwritten
 
 write_dataframe_to_db(
@@ -42,8 +45,8 @@ write_dataframe_to_db(
   schema = schema,
   table_name = "test_iris",
   dataframe = test_iris,
-  append_to_existing = TRUE, # Setting this as TRUE ensures append to existing - default is FALSE
-  batch_size = 1e5, # Set as any integer or leave as default if less than about 100 K rows
+  append_to_existing = TRUE, # Setting this as TRUE ensures append to existing
+  batch_size = 1e5, # Set as any integer or leave as default
   versioned_table = FALSE
 ) # Unless definitely need history table, set as FALSE (default)
 

--- a/man/read_table_from_db.Rd
+++ b/man/read_table_from_db.Rd
@@ -43,7 +43,7 @@ read_table_from_db(
   server = "my_server",
   table_name = "my_table",
   columns = c("column1", "column2"),
-  filter_stmt = "column1 < 5 & column2 == 'b'")
+  filter_stmt = "column1 < 5 & column2 == 'b'"
 )
 }
 }

--- a/man/read_table_from_db.Rd
+++ b/man/read_table_from_db.Rd
@@ -25,16 +25,16 @@ read_table_from_db(
 \item{columns}{Optional vector of column names to select.}
 
 \item{filter_stmt}{Optional filter statement - this should be a character
-expression in the format of a \code{dplyr::filter()} query,
-for example \verb{"Species == "virginica"} and it will be translated to SQL
-using \link[dbplyr]{translate_sql}.}
+expression in the format of a \code{\link[dplyr:filter]{dplyr::filter()}} query,
+for example \code{"Species == 'virginica'"} and it will be translated to SQL
+using \code{\link[dbplyr:translate_sql]{dbplyr::translate_sql()}}.}
 }
 \value{
 Dataframe of table.
 }
 \description{
 If you are confident in writing SQL you may prefer to
-Use \link[RtoSQLServer]{execute_sql} function instead.
+use the \code{\link[=execute_sql]{execute_sql()}} function instead.
 }
 \examples{
 \dontrun{

--- a/man/read_table_from_db.Rd
+++ b/man/read_table_from_db.Rd
@@ -2,9 +2,16 @@
 % Please edit documentation in R/read_table.R
 \name{read_table_from_db}
 \alias{read_table_from_db}
-\title{Read a SQL Server table into an R dataframe,}
+\title{Read a SQL Server table into an R dataframe.}
 \usage{
-read_table_from_db(database, server, schema, table_name, columns = NULL)
+read_table_from_db(
+  database,
+  server,
+  schema,
+  table_name,
+  columns = NULL,
+  filter_stmt = NULL
+)
 }
 \arguments{
 \item{database}{Database containing table to read.}
@@ -16,12 +23,18 @@ read_table_from_db(database, server, schema, table_name, columns = NULL)
 \item{table_name}{Name of table in database to read.}
 
 \item{columns}{Optional vector of column names to select.}
+
+\item{filter_stmt}{Optional filter statement - this should be a character
+expression in the format of a \code{dplyr::filter()} query,
+for example \verb{"Species == "virginica"} and it will be translated to SQL
+using \link[dbplyr]{translate_sql}.}
 }
 \value{
 Dataframe of table.
 }
 \description{
-Read a SQL Server table into an R dataframe,
+If you are confident in writing SQL you may prefer to
+Use \link[RtoSQLServer]{execute_sql} function instead.
 }
 \examples{
 \dontrun{
@@ -29,7 +42,8 @@ read_table_from_db(
   database = "my_database",
   server = "my_server",
   table_name = "my_table",
-  columns = c("column1", "column2")
+  columns = c("column1", "column2"),
+  filter_stmt = "column1 < 5 & column2 == 'b'")
 )
 }
 }

--- a/tests/testthat/test-read_table.R
+++ b/tests/testthat/test-read_table.R
@@ -13,7 +13,8 @@ test_that("select sql works", {
   select_list <- "[col_a], [col_b]"
 
   filter_ex <- dbplyr::translate_sql(col_a == "test1" & col_b == "test2",
-                                     con = dbplyr::simulate_mssql())
+    con = dbplyr::simulate_mssql()
+  )
 
   filter_ex <- gsub("(`|\")([^=]*)\\1", "[\\2]", filter_ex)
 

--- a/tests/testthat/test-read_table.R
+++ b/tests/testthat/test-read_table.R
@@ -5,11 +5,26 @@ test_that("column formatting works", {
 })
 
 test_that("select sql works", {
-  test_sql <- "SELECT [col_a], [col_b] FROM [test_schema].[test_tbl];"
+  test_sql <- paste(
+    "SELECT [col_a], [col_b] FROM [test_schema].[test_tbl]",
+    "WHERE [col_a] = 'test1' AND [col_b] = 'test2';"
+  )
+
   select_list <- "[col_a], [col_b]"
+
+  filter_ex <- dbplyr::translate_sql(col_a == "test1" & col_b == "test2",
+                                     con = dbplyr::simulate_mssql())
+
+  filter_ex <- gsub("(`|\")([^=]*)\\1", "[\\2]", filter_ex)
+
+  mockery::stub(create_read_sql, "format_filter", filter_ex)
+
   expect_equal(create_read_sql(
-    select_list,
-    "test_schema",
-    "test_tbl"
+    server = "test",
+    database = "test",
+    schema = "test_schema",
+    select_list = select_list,
+    table_name = "test_tbl",
+    filter_stmt = "col_a == 'test1' & col_b = 'test2'"
   ), test_sql)
 })


### PR DESCRIPTION
Using `dbplyr::translate_sql` to convert R filter syntax to SQL syntax. 
New dependencies `dbplyr` and `rlang`.
Updated readme with instructions on how to use filtering